### PR TITLE
set stoch_rest file name for mom

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -3738,7 +3738,7 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
   endif
 
   ! initialize stochastic physics
-  call stochastics_init(CS%dt_therm, CS%G, CS%GV, CS%stoch_CS, param_file, diag, Time)
+  call stochastics_init(CS%dt_therm, CS%G, CS%GV, CS%stoch_CS, param_file, diag, Time, input_restart_file)
 
   call callTree_leave("initialize_MOM()")
   call cpu_clock_end(id_clock_init)


### PR DESCRIPTION
@iangrooms with these changes I am able to pass a cesm restart test
/glade/derecho/scratch/jedwards/ERS_Ld5.ne30pg3_t232.B1850C_LTso.derecho_intel.20250716_113431_qvc1l4
I didn't end up using the namelist variable as a namelist variable, I set it internally based on the mom restart file name.   If this approach is okay we can probably remove that variable from the namelist and just make it a variable that I can pass into  init_stochastic_physics_ocn